### PR TITLE
Remove duplicate train_test_split rows in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ X, y = load_iris(return_X_y=true)
 using NovaML.ModelSelection
 Xtrn, Xtst, ytrn, ytst = train_test_split(X, y, test_size=0.2)
 
-using NovaML.ModelSelection
-Xtrn, Xtst, ytrn, ytst = train_test_split(X, y, test_size=0.2)
-
 # Scale features
 using NovaML.PreProcessing
 scaler = StandardScaler()


### PR DESCRIPTION
The rows 

```julia
using NovaML.ModelSelection
Xtrn, Xtst, ytrn, ytst = train_test_split(X, y, test_size=0.2)
```

are duplicated in README.MD so the simple PR removes the repeated one.